### PR TITLE
fix: fixed css links error when the base path contains protocols

### DIFF
--- a/src/browser-utils.js
+++ b/src/browser-utils.js
@@ -69,7 +69,7 @@ export function toggleTheme(opts) {
   const href = options.customLinkHref(
     `${basePath || ""}/${
       browerPreprocessorOptions.outputDir || assetsDir || ""
-    }/${options.scopeName}.css`.replace(/\/+(?=\/)/g, "")
+    }/${options.scopeName}.css`.replace(/(?<!:)\/+(?=\/)/g, "")
   );
   if (styleLink) {
     // 假如存在id为theme-link-tag 的link标签，创建一个新的添加上去加载完成后再60毫秒后移除旧的

--- a/src/common/addExtractThemeLinkTag.js
+++ b/src/common/addExtractThemeLinkTag.js
@@ -1,5 +1,5 @@
 import { addScopnameToHtmlClassname } from "@zougt/some-loader-utils";
-import path from "path";
+
 export function addExtractThemeLinkTag({
   html,
   defaultOptions,
@@ -36,7 +36,7 @@ export function addExtractThemeLinkTag({
 
       const linkHref = `${base ? `${base}/` : base}${
         outputDir || config.build.assetsDir
-      }/${filename}.css`.replace(/\/+(?=\/)/g, "");
+      }/${filename}.css`.replace(/(?<!:)\/+(?=\/)/g, "");
       const tag = {
         tag: "link",
         attrs: {


### PR DESCRIPTION
before:
https:////xx.com/xxx///theme.css  -> https:/xx.com/xxx/theme.css

after:
https:////xx.com/xxx///theme.css -> https://xx.com/xxx/theme.css